### PR TITLE
chore: exclude sensitive credential files from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ android/app/release/
 # Environment
 .env
 *.env
+
+# Sensitive credential files
+.github_token
+.aws_credentials


### PR DESCRIPTION
Adds `.github_token` and `.aws_credentials` to `.gitignore` to prevent sensitive credential files from being accidentally committed to the repository.

**Files excluded:**
- `.github_token` — GitHub Personal Access Token
- `.aws_credentials` — AWS IAM access key credentials