### PR TITLE
feat(backend): add push mode + POST /admin/ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,120 @@
-# fueller
-An Android app project to show you where the cheapest fuel is nearby.
+# Fueller backend
+
+A Ktor server that serves UK petrol-station and fuel-price data to the Fueller Android app.
+
+## Deployment modes
+
+The backend can populate its in-memory cache in one of two ways. The `/api/search` contract served to mobile clients is identical in both.
+
+### Pull mode (default)
+
+The backend periodically calls the UK government Fuel Finder API directly, using OAuth2 client credentials. Used in development and once the deployed backend's egress IP is whitelisted by the Fuel Finder team.
+
+Required configuration:
+
+- `FUEL_FINDER_MODE=pull` (or unset — pull is the default)
+- `FUEL_FINDER_CLIENT_ID`
+- `FUEL_FINDER_CLIENT_SECRET`
+
+Optional:
+
+- `fuelfinder.baseUrl` (default: `https://stg.fuel-finder.ics.gov.uk`)
+- `fuelfinder.priceRefreshMinutes` (default: 30)
+- `fuelfinder.stationRefreshHours` (default: 24)
+- `fuelfinder.staleAfterMinutes` (default: 90)
+
+### Push mode
+
+A separate ingester (typically a script on a whitelisted laptop or a CI job) fetches data from Fuel Finder and POSTs it to the backend via `POST /admin/ingest`. The backend stores no Fuel Finder credentials in this mode.
+
+Required configuration:
+
+- `FUEL_FINDER_MODE=push`
+- `INGEST_TOKEN` (32+ bytes random; shared with the ingester)
+
+Optional:
+
+- `ingest.maxBodyBytes` (default: 33,554,432 — 32 MiB)
+- `fuelfinder.staleAfterMinutes` (default: 90)
+
+The first `/api/search` request after startup returns 503 until the first ingest lands. If no ingest arrives for longer than the stale threshold, `/api/search` returns 503 again until the cache is refreshed.
+
+## Endpoints
+
+### `GET /api/search?postcode=SW1A1AA&radius=5`
+
+Public endpoint consumed by the Android app. Identical contract in both modes.
+
+Returns 503 if the cache is empty (`dataLoaded = false`) or stale (`isStale = true`).
+
+### `GET /api/health`
+
+```json
+{
+  "status": "ok",
+  "mode": "push",
+  "dataLoaded": true,
+  "isStale": false,
+  "lastPriceRefresh": "2026-04-29T20:00:00Z",
+  "nextPriceRefresh": "2026-04-29T20:30:00Z",
+  "stationCount": 8421,
+  "priceCount": 8237,
+  "ingestSource": "laptop-push",
+  "ingesterVersion": "1.0.0"
+}
+```
+
+External monitoring should poll this endpoint and alert when `isStale: true` or non-200.
+
+### `POST /admin/ingest` (push mode only)
+
+```
+POST /admin/ingest
+Content-Type: application/json
+X-Ingest-Token: <secret>
+
+{
+  "fetched_at": "2026-04-29T20:00:00Z",
+  "ingester_version": "1.0.0",
+  "stations": [ <Fuel Finder station objects, passthrough> ],
+  "prices":   [ <Fuel Finder price-record objects, passthrough> ]
+}
+```
+
+| Status | Meaning |
+|---|---|
+| 200 | Accepted, cache swapped atomically |
+| 400 | Malformed JSON, missing fields, empty arrays, or unparseable `fetched_at` |
+| 401 | Missing or wrong `X-Ingest-Token` |
+| 409 | `fetched_at` is older than the currently cached snapshot (out-of-order) |
+| 413 | Payload exceeds `ingest.maxBodyBytes` |
+| 503 | Server is in pull mode |
+
+## Building
+
+```
+cd backend
+./gradlew build               # compile + tests
+./gradlew shadowJar           # produces backend/build/libs/fueller-backend.jar
+```
+
+## Running locally
+
+Pull mode (development):
+
+```
+export FUEL_FINDER_MODE=pull
+export FUEL_FINDER_CLIENT_ID=...
+export FUEL_FINDER_CLIENT_SECRET=...
+java -jar backend/build/libs/fueller-backend.jar
+```
+
+Push mode:
+
+```
+export FUEL_FINDER_MODE=push
+export INGEST_TOKEN=$(openssl rand -base64 32 | tr -d '=' | tr '/+' '_-')
+java -jar backend/build/libs/fueller-backend.jar
+```
+
+See `Fueller_LaptopIngest_Design.md` in the workspace folder for the full design rationale and the laptop-side ingester spec.

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -38,8 +38,10 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.4.14")
 
     // --- tests ---
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "uk.co.fueller"
-version = "0.1.0"
+version = "0.2.0"
 
 application {
     mainClass.set("uk.co.fueller.backend.ApplicationKt")
@@ -17,6 +17,7 @@ repositories {
 }
 
 val ktorVersion = "2.3.12"
+val kotlinVersion = "1.9.24"
 
 dependencies {
     implementation("io.ktor:ktor-server-core:$ktorVersion")
@@ -35,10 +36,19 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
     implementation("ch.qos.logback:logback-classic:1.4.14")
+
+    // --- tests ---
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 }
 
 kotlin {
     jvmToolchain(17)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.serialization") version "1.9.24"
     application
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 group = "uk.co.fueller"

--- a/backend/src/main/kotlin/uk/co/fueller/backend/Application.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/Application.kt
@@ -11,19 +11,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
+import java.time.Duration
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
 fun Application.module() {
     val config = environment.config
 
-    val clientId = config.propertyOrNull("fuelfinder.clientId")?.getString()
-        ?: System.getenv("FUEL_FINDER_CLIENT_ID")
-        ?: error("FUEL_FINDER_CLIENT_ID not set")
+    // Mode: "pull" (existing scheduled fetch from Fuel Finder) or "push"
+    // (laptop ingester POSTs to /admin/ingest). Defaults to "pull" for backwards compat.
+    val mode = (config.propertyOrNull("fuelfinder.mode")?.getString()
+        ?: System.getenv("FUEL_FINDER_MODE")
+        ?: "pull").lowercase()
 
-    val clientSecret = config.propertyOrNull("fuelfinder.clientSecret")?.getString()
-        ?: System.getenv("FUEL_FINDER_CLIENT_SECRET")
-        ?: error("FUEL_FINDER_CLIENT_SECRET not set")
+    require(mode == "pull" || mode == "push") {
+        "fuelfinder.mode must be 'pull' or 'push' (got '$mode')"
+    }
 
     val baseUrl = config.propertyOrNull("fuelfinder.baseUrl")?.getString()
         ?: "https://www.fuel-finder.service.gov.uk"
@@ -33,6 +36,34 @@ fun Application.module() {
 
     val stationRefreshHours = config.propertyOrNull("fuelfinder.stationRefreshHours")?.getString()?.toLongOrNull()
         ?: 24L
+
+    val staleAfterMinutes = config.propertyOrNull("fuelfinder.staleAfterMinutes")?.getString()?.toLongOrNull()
+        ?: 90L
+
+    // Pull-mode credentials. Optional in push mode (the laptop holds them).
+    val clientId = config.propertyOrNull("fuelfinder.clientId")?.getString()
+        ?: System.getenv("FUEL_FINDER_CLIENT_ID")
+
+    val clientSecret = config.propertyOrNull("fuelfinder.clientSecret")?.getString()
+        ?: System.getenv("FUEL_FINDER_CLIENT_SECRET")
+
+    // Push-mode shared secret. Optional in pull mode.
+    val ingestToken = config.propertyOrNull("ingest.token")?.getString()
+        ?: System.getenv("INGEST_TOKEN")
+
+    val maxIngestBytes = config.propertyOrNull("ingest.maxBodyBytes")?.getString()?.toLongOrNull()
+        ?: 33_554_432L  // 32 MiB
+
+    // Per-mode validation: fail fast at startup if required config is missing.
+    when (mode) {
+        "pull" -> {
+            require(!clientId.isNullOrBlank()) { "FUEL_FINDER_CLIENT_ID is required when mode = 'pull'" }
+            require(!clientSecret.isNullOrBlank()) { "FUEL_FINDER_CLIENT_SECRET is required when mode = 'pull'" }
+        }
+        "push" -> {
+            require(!ingestToken.isNullOrBlank()) { "INGEST_TOKEN is required when mode = 'push'" }
+        }
+    }
 
     install(ContentNegotiation) {
         json(Json {
@@ -44,6 +75,7 @@ fun Application.module() {
     install(CORS) {
         anyHost()
         allowHeader(HttpHeaders.ContentType)
+        allowHeader("X-Ingest-Token")
     }
 
     install(StatusPages) {
@@ -53,17 +85,44 @@ fun Application.module() {
         }
     }
 
-    val client = FuelFinderClient(baseUrl, clientId, clientSecret)
-    val cache = DataCache(client, priceRefreshMinutes, stationRefreshHours)
+    // The FuelFinderClient is constructed in both modes:
+    //   - pull mode: used for OAuth2 + station/price fetches AND postcode geocoding.
+    //   - push mode: used only for postcode geocoding via postcodes.io (no OAuth needed).
+    val client = FuelFinderClient(
+        baseUrl = baseUrl,
+        clientId = clientId ?: "",
+        clientSecret = clientSecret ?: ""
+    )
 
-    val cacheScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    cache.start(cacheScope)
+    val cache = DataCache(
+        client = client,
+        priceRefreshMinutes = priceRefreshMinutes,
+        stationRefreshHours = stationRefreshHours,
+        staleAfter = Duration.ofMinutes(staleAfterMinutes)
+    )
 
-    environment.monitor.subscribe(ApplicationStopped) {
-        cache.stop()
+    if (mode == "pull") {
+        val cacheScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        cache.start(cacheScope)
+        environment.monitor.subscribe(ApplicationStopped) { cache.stop() }
+        log.info(
+            "Started in PULL mode (price refresh ${priceRefreshMinutes}m, station refresh ${stationRefreshHours}h, " +
+                "stale threshold ${staleAfterMinutes}m)"
+        )
+    } else {
+        log.info(
+            "Started in PUSH mode — cache populated by POST /admin/ingest. " +
+                "Stale threshold ${staleAfterMinutes}m."
+        )
     }
 
-    configureRoutes(cache, client)
+    configureRoutes(
+        cache = cache,
+        client = client,
+        mode = mode,
+        ingestToken = ingestToken,
+        maxIngestBytes = maxIngestBytes
+    )
 
     log.info("Fueller backend started on port ${config.propertyOrNull("ktor.deployment.port")?.getString() ?: "8080"}")
 }

--- a/backend/src/main/kotlin/uk/co/fueller/backend/DataCache.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/DataCache.kt
@@ -2,32 +2,53 @@ package uk.co.fueller.backend
 
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
+/**
+ * In-memory store of stations and prices, served to /api/search.
+ *
+ * Two modes of update:
+ *   - Pull (start()):           a coroutine periodically calls FuelFinderClient and reloads from upstream.
+ *   - Push (replaceFromIngest): an external ingester (laptop or scheduled job) supplies the data via POST /admin/ingest.
+ *
+ * Reads ([findNearby]) operate on immutable snapshots held in AtomicReferences so writers swap state atomically.
+ */
 class DataCache(
     private val client: FuelFinderClient,
     private val priceRefreshMinutes: Long = 30,
-    private val stationRefreshHours: Long = 24
+    private val stationRefreshHours: Long = 24,
+    private val staleAfter: Duration = Duration.ofMinutes(90)
 ) {
     private val log = LoggerFactory.getLogger(DataCache::class.java)
     private val formatter = DateTimeFormatter.ISO_INSTANT
 
-    private val stations = ConcurrentHashMap<String, FuelFinderStation>()
-    private val prices = ConcurrentHashMap<String, List<FuelPrice>>()
+    private val stations = AtomicReference<Map<String, FuelFinderStation>>(emptyMap())
+    private val prices = AtomicReference<Map<String, List<FuelPrice>>>(emptyMap())
 
     @Volatile var lastPriceRefresh: Instant = Instant.EPOCH
         private set
     @Volatile var lastStationRefresh: Instant = Instant.EPOCH
+        private set
+    @Volatile var ingesterVersion: String? = null
         private set
 
     val nextPriceRefresh: Instant
         get() = lastPriceRefresh.plusSeconds(priceRefreshMinutes * 60)
 
     val isLoaded: Boolean
-        get() = stations.isNotEmpty()
+        get() = stations.get().isNotEmpty()
+
+    val isStale: Boolean
+        get() = !isLoaded || Instant.now().isAfter(lastPriceRefresh.plus(staleAfter))
+
+    val stationCount: Int
+        get() = stations.get().size
+
+    val priceCount: Int
+        get() = prices.get().size
 
     private var refreshJob: Job? = null
 
@@ -64,10 +85,9 @@ class DataCache(
     private suspend fun loadStations() {
         log.info("Loading all stations...")
         val fetched = client.fetchAllStations()
-        stations.clear()
-        fetched.forEach { stations[it.nodeId] = it }
+        stations.set(fetched.associateBy { it.nodeId })
         lastStationRefresh = Instant.now()
-        log.info("Loaded ${stations.size} stations")
+        log.info("Loaded ${stations.get().size} stations")
     }
 
     private suspend fun loadPrices(incremental: Boolean = false) {
@@ -77,18 +97,49 @@ class DataCache(
 
         log.info(if (since != null) "Loading price updates since $since" else "Loading all prices...")
         val fetched = client.fetchAllPrices(since)
-        fetched.forEach { record ->
-            prices[record.nodeId] = record.fuelPrices
+
+        if (incremental && since != null) {
+            // Merge incremental updates into the existing snapshot.
+            val merged = prices.get().toMutableMap()
+            fetched.forEach { record -> merged[record.nodeId] = record.fuelPrices }
+            prices.set(merged)
+        } else {
+            prices.set(fetched.associate { it.nodeId to it.fuelPrices })
         }
         lastPriceRefresh = Instant.now()
-        log.info("Loaded prices for ${fetched.size} stations (total cached: ${prices.size})")
+        log.info("Loaded prices for ${fetched.size} stations (total cached: ${prices.get().size})")
+    }
+
+    /**
+     * Atomically replace the cache with data from the laptop ingester (push mode).
+     * Replaces all stations and prices in a single, externally-visible step.
+     *
+     * @param fetchedAt the upstream fetch timestamp (becomes [lastPriceRefresh]).
+     */
+    fun replaceFromIngest(
+        newStations: List<FuelFinderStation>,
+        newPrices: List<FuelFinderPriceRecord>,
+        fetchedAt: Instant,
+        ingesterVersion: String? = null
+    ) {
+        stations.set(newStations.associateBy { it.nodeId })
+        prices.set(newPrices.associate { it.nodeId to it.fuelPrices })
+        lastPriceRefresh = fetchedAt
+        lastStationRefresh = fetchedAt
+        this.ingesterVersion = ingesterVersion
+        log.info(
+            "Ingest applied: ${newStations.size} stations, ${newPrices.size} price records, " +
+                "fetched_at=$fetchedAt, ingester=${ingesterVersion ?: "(unknown)"}"
+        )
     }
 
     /** Find stations within [radiusMiles] of the given coordinates, sorted by distance. */
     fun findNearby(lat: Double, lon: Double, radiusMiles: Double): List<StationWithPrices> {
         val nextRefresh = DateTimeFormatter.ISO_INSTANT.format(nextPriceRefresh)
+        val stationSnapshot = stations.get()
+        val priceSnapshot = prices.get()
 
-        return stations.values
+        return stationSnapshot.values
             .filter { it.location?.latitude != null && it.location.longitude != null }
             .filter { it.permanentClosure != true }
             .map { station ->
@@ -102,7 +153,7 @@ class DataCache(
             .filter { (_, dist) -> dist <= radiusMiles }
             .sortedBy { (_, dist) -> dist }
             .map { (station, dist) ->
-                val stationPrices = prices[station.nodeId] ?: emptyList()
+                val stationPrices = priceSnapshot[station.nodeId] ?: emptyList()
                 val loc = station.location!!
 
                 val address = listOfNotNull(

--- a/backend/src/main/kotlin/uk/co/fueller/backend/IngestRoute.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/IngestRoute.kt
@@ -1,0 +1,121 @@
+package uk.co.fueller.backend
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.slf4j.LoggerFactory
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+private val log = LoggerFactory.getLogger("IngestRoute")
+
+/**
+ * Registers POST /admin/ingest. Active only in push mode; in pull mode the route
+ * is still registered but always returns 503 so misrouted requests are visible
+ * rather than 404'd.
+ */
+fun Routing.ingestRoutes(
+    cache: DataCache,
+    mode: String,
+    ingestToken: String?,
+    maxIngestBytes: Long
+) {
+    post("/admin/ingest") {
+        // 1. Mode check.
+        if (mode != "push") {
+            call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("ingest disabled in pull mode"))
+            return@post
+        }
+
+        // 2. Token check (constant-time). In push mode the startup validation in
+        //    Application.module() guarantees ingestToken is non-blank.
+        val provided = call.request.header("X-Ingest-Token")
+        val expected = ingestToken
+        if (expected.isNullOrBlank() || !tokensMatch(provided, expected)) {
+            log.warn("Rejected ingest from ${call.request.local.remoteHost}: bad/missing token")
+            call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Unauthorized"))
+            return@post
+        }
+
+        // 3. Body size guard. Content-Length is advisory, but rejecting an
+        //    oversized declared length avoids buffering a huge body before parsing.
+        val contentLength = call.request.header(HttpHeaders.ContentLength)?.toLongOrNull()
+        if (contentLength != null && contentLength > maxIngestBytes) {
+            call.respond(HttpStatusCode.PayloadTooLarge, ErrorResponse("payload too large"))
+            return@post
+        }
+
+        // 4. Parse and validate.
+        val request: IngestRequest = try {
+            call.receive()
+        } catch (e: Exception) {
+            log.warn("Malformed ingest payload", e)
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("malformed payload: ${e.message}"))
+            return@post
+        }
+
+        val fetchedAt = try {
+            Instant.parse(request.fetchedAt)
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse("fetched_at must be ISO-8601 UTC (got '${request.fetchedAt}')")
+            )
+            return@post
+        }
+
+        if (request.stations.isEmpty()) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("stations array must not be empty"))
+            return@post
+        }
+        if (request.prices.isEmpty()) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("prices array must not be empty"))
+            return@post
+        }
+
+        // 5. Out-of-order check: refuse a payload whose fetched_at is older than
+        //    or equal to the currently cached one. The first ever ingest passes
+        //    this check because lastPriceRefresh starts at Instant.EPOCH.
+        val previousFetchedAt = cache.lastPriceRefresh
+        if (previousFetchedAt != Instant.EPOCH && !fetchedAt.isAfter(previousFetchedAt)) {
+            call.respond(
+                HttpStatusCode.Conflict,
+                StaleIngestResponse(
+                    error = "stale ingest",
+                    currentFetchedAt = DateTimeFormatter.ISO_INSTANT.format(previousFetchedAt)
+                )
+            )
+            return@post
+        }
+
+        // 6. Apply atomically.
+        cache.replaceFromIngest(
+            newStations = request.stations,
+            newPrices = request.prices,
+            fetchedAt = fetchedAt,
+            ingesterVersion = request.ingesterVersion
+        )
+
+        call.respond(
+            IngestResponse(
+                stations = request.stations.size,
+                prices = request.prices.size,
+                fetchedAt = DateTimeFormatter.ISO_INSTANT.format(fetchedAt),
+                previousFetchedAt = if (previousFetchedAt != Instant.EPOCH)
+                    DateTimeFormatter.ISO_INSTANT.format(previousFetchedAt) else null,
+                ingesterVersion = request.ingesterVersion
+            )
+        )
+    }
+}
+
+/** Constant-time string comparison; defeats timing-side-channel attacks on the ingest token. */
+private fun tokensMatch(provided: String?, expected: String): Boolean {
+    if (provided == null) return false
+    val a = provided.toByteArray(Charsets.UTF_8)
+    val b = expected.toByteArray(Charsets.UTF_8)
+    return MessageDigest.isEqual(a, b)
+}

--- a/backend/src/main/kotlin/uk/co/fueller/backend/Models.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/Models.kt
@@ -125,7 +125,44 @@ data class ErrorResponse(
 @Serializable
 data class HealthResponse(
     val status: String,
+    val mode: String,
     val dataLoaded: Boolean,
+    val isStale: Boolean,
     val lastPriceRefresh: String,
-    val nextPriceRefresh: String
+    val nextPriceRefresh: String,
+    val stationCount: Int,
+    val priceCount: Int,
+    val ingestSource: String,
+    val ingesterVersion: String? = null
+)
+
+// --- Laptop-ingest models (push mode) ---
+
+/**
+ * Payload accepted by POST /admin/ingest.
+ *
+ * `stations` and `prices` are passthroughs of the upstream Fuel Finder responses
+ * (see FuelFinderClient.fetchAllStations / fetchAllPrices).
+ */
+@Serializable
+data class IngestRequest(
+    @SerialName("fetched_at") val fetchedAt: String,
+    @SerialName("ingester_version") val ingesterVersion: String? = null,
+    val stations: List<FuelFinderStation> = emptyList(),
+    val prices: List<FuelFinderPriceRecord> = emptyList()
+)
+
+@Serializable
+data class IngestResponse(
+    val stations: Int,
+    val prices: Int,
+    @SerialName("fetched_at") val fetchedAt: String,
+    @SerialName("previous_fetched_at") val previousFetchedAt: String? = null,
+    @SerialName("ingester_version") val ingesterVersion: String? = null
+)
+
+@Serializable
+data class StaleIngestResponse(
+    val error: String,
+    @SerialName("current_fetched_at") val currentFetchedAt: String
 )

--- a/backend/src/main/kotlin/uk/co/fueller/backend/Routes.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/Routes.kt
@@ -6,7 +6,13 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import java.time.format.DateTimeFormatter
 
-fun Application.configureRoutes(cache: DataCache, client: FuelFinderClient) {
+fun Application.configureRoutes(
+    cache: DataCache,
+    client: FuelFinderClient,
+    mode: String,
+    ingestToken: String?,
+    maxIngestBytes: Long
+) {
     routing {
         get("/api/search") {
             val postcode = call.parameters["postcode"]
@@ -23,6 +29,11 @@ fun Application.configureRoutes(cache: DataCache, client: FuelFinderClient) {
 
             if (!cache.isLoaded) {
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Data is still loading, please try again shortly"))
+                return@get
+            }
+
+            if (cache.isStale) {
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Data is stale, please try again shortly"))
                 return@get
             }
 
@@ -51,11 +62,19 @@ fun Application.configureRoutes(cache: DataCache, client: FuelFinderClient) {
             call.respond(
                 HealthResponse(
                     status = "ok",
+                    mode = mode,
                     dataLoaded = cache.isLoaded,
+                    isStale = cache.isStale,
                     lastPriceRefresh = DateTimeFormatter.ISO_INSTANT.format(cache.lastPriceRefresh),
-                    nextPriceRefresh = DateTimeFormatter.ISO_INSTANT.format(cache.nextPriceRefresh)
+                    nextPriceRefresh = DateTimeFormatter.ISO_INSTANT.format(cache.nextPriceRefresh),
+                    stationCount = cache.stationCount,
+                    priceCount = cache.priceCount,
+                    ingestSource = if (mode == "push") "laptop-push" else "scheduled-pull",
+                    ingesterVersion = cache.ingesterVersion
                 )
             )
         }
+
+        ingestRoutes(cache, mode, ingestToken, maxIngestBytes)
     }
 }

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -8,10 +8,27 @@ ktor {
 }
 
 fuelfinder {
-    # Set these via environment variables: FUEL_FINDER_CLIENT_ID, FUEL_FINDER_CLIENT_SECRET
+    # Mode: "pull" (existing - backend fetches from Fuel Finder) or "push" (laptop ingester feeds /admin/ingest).
+    mode = "pull"
+    mode = ${?FUEL_FINDER_MODE}
+
+    # Required when mode = "pull". Optional (and unused) when mode = "push".
     clientId = ${?FUEL_FINDER_CLIENT_ID}
     clientSecret = ${?FUEL_FINDER_CLIENT_SECRET}
     baseUrl = "https://stg.fuel-finder.ics.gov.uk"
+
     priceRefreshMinutes = 30
     stationRefreshHours = 24
+
+    # Cache is considered stale this many minutes after the last refresh / ingest.
+    # /api/search returns 503 when the cache is stale, even if it has data.
+    staleAfterMinutes = 90
+}
+
+ingest {
+    # Required when mode = "push". Shared secret used for the X-Ingest-Token header on POST /admin/ingest.
+    token = ${?INGEST_TOKEN}
+
+    # Maximum body size for /admin/ingest in bytes. Default 32 MiB.
+    maxBodyBytes = 33554432
 }

--- a/backend/src/test/kotlin/uk/co/fueller/backend/DataCacheTest.kt
+++ b/backend/src/test/kotlin/uk/co/fueller/backend/DataCacheTest.kt
@@ -1,0 +1,149 @@
+package uk.co.fueller.backend
+
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DataCacheTest {
+
+    private fun mkCache(staleAfterMin: Long = 90L) = DataCache(
+        client = FuelFinderClient("https://example.invalid", "stub", "stub"),
+        priceRefreshMinutes = 30,
+        stationRefreshHours = 24,
+        staleAfter = Duration.ofMinutes(staleAfterMin)
+    )
+
+    private fun mkStation(nodeId: String, lat: Double = 51.5, lon: Double = -0.1) = FuelFinderStation(
+        nodeId = nodeId,
+        tradingName = "Station $nodeId",
+        brandName = "BrandX",
+        location = StationLocation(latitude = lat, longitude = lon, postcode = "SW1A 1AA")
+    )
+
+    private fun mkPrice(nodeId: String, ppl: Double = 145.9) = FuelFinderPriceRecord(
+        nodeId = nodeId,
+        fuelPrices = listOf(
+            FuelPrice(fuelType = "B7", price = ppl, priceLastUpdated = "2026-04-29T19:00:00Z")
+        )
+    )
+
+    @Test
+    fun `empty cache reports not loaded and stale`() {
+        val cache = mkCache()
+        assertFalse(cache.isLoaded)
+        assertTrue(cache.isStale)
+        assertEquals(0, cache.stationCount)
+        assertEquals(0, cache.priceCount)
+        assertNull(cache.ingesterVersion)
+    }
+
+    @Test
+    fun `replaceFromIngest populates the cache`() {
+        val cache = mkCache()
+        val now = Instant.now()
+        cache.replaceFromIngest(
+            newStations = listOf(mkStation("a"), mkStation("b")),
+            newPrices = listOf(mkPrice("a"), mkPrice("b")),
+            fetchedAt = now,
+            ingesterVersion = "1.0.0"
+        )
+        assertTrue(cache.isLoaded)
+        assertFalse(cache.isStale)
+        assertEquals(2, cache.stationCount)
+        assertEquals(2, cache.priceCount)
+        assertEquals(now, cache.lastPriceRefresh)
+        assertEquals("1.0.0", cache.ingesterVersion)
+    }
+
+    @Test
+    fun `replaceFromIngest replaces all previous data, no leftover keys`() {
+        val cache = mkCache()
+        cache.replaceFromIngest(
+            newStations = (1..100).map { mkStation("s$it") },
+            newPrices = (1..100).map { mkPrice("s$it") },
+            fetchedAt = Instant.now().minusSeconds(10),
+            ingesterVersion = "1.0.0"
+        )
+        assertEquals(100, cache.stationCount)
+
+        // Replace with a smaller, disjoint set.
+        cache.replaceFromIngest(
+            newStations = (1..3).map { mkStation("t$it") },
+            newPrices = (1..3).map { mkPrice("t$it") },
+            fetchedAt = Instant.now(),
+            ingesterVersion = "1.0.1"
+        )
+        assertEquals(3, cache.stationCount)
+        assertEquals(3, cache.priceCount)
+        assertEquals("1.0.1", cache.ingesterVersion)
+
+        val results = cache.findNearby(51.5, -0.1, 50.0)
+        assertTrue(results.isNotEmpty())
+        assertTrue(results.all { it.nodeId.startsWith("t") }) {
+            "expected only t* nodes after second ingest, got: ${results.map { it.nodeId }}"
+        }
+    }
+
+    @Test
+    fun `isStale becomes true after the configured threshold`() {
+        val cache = mkCache(staleAfterMin = 90)
+        cache.replaceFromIngest(
+            newStations = listOf(mkStation("a")),
+            newPrices = listOf(mkPrice("a")),
+            fetchedAt = Instant.now().minus(Duration.ofMinutes(91)),
+            ingesterVersion = "1.0.0"
+        )
+        assertTrue(cache.isLoaded)
+        assertTrue(cache.isStale)
+    }
+
+    @Test
+    fun `isStale stays false within the threshold`() {
+        val cache = mkCache(staleAfterMin = 90)
+        cache.replaceFromIngest(
+            newStations = listOf(mkStation("a")),
+            newPrices = listOf(mkPrice("a")),
+            fetchedAt = Instant.now().minus(Duration.ofMinutes(60)),
+            ingesterVersion = "1.0.0"
+        )
+        assertFalse(cache.isStale)
+    }
+
+    @Test
+    fun `findNearby honours radius and sorts by distance`() {
+        val cache = mkCache()
+        cache.replaceFromIngest(
+            newStations = listOf(
+                mkStation("near", lat = 51.5001, lon = -0.1001),  // ~10m from origin
+                mkStation("far",  lat = 52.0,    lon = -0.1)      // ~35 miles north
+            ),
+            newPrices = listOf(mkPrice("near"), mkPrice("far")),
+            fetchedAt = Instant.now(),
+            ingesterVersion = "1.0.0"
+        )
+
+        val small = cache.findNearby(51.5, -0.1, radiusMiles = 1.0)
+        assertEquals(listOf("near"), small.map { it.nodeId })
+
+        val wide = cache.findNearby(51.5, -0.1, radiusMiles = 50.0)
+        assertEquals(listOf("near", "far"), wide.map { it.nodeId })
+    }
+
+    @Test
+    fun `findNearby filters out permanently closed stations`() {
+        val cache = mkCache()
+        val closed = mkStation("closed").copy(permanentClosure = true)
+        cache.replaceFromIngest(
+            newStations = listOf(mkStation("open"), closed),
+            newPrices = listOf(mkPrice("open"), mkPrice("closed")),
+            fetchedAt = Instant.now(),
+            ingesterVersion = "1.0.0"
+        )
+        val results = cache.findNearby(51.5, -0.1, 50.0)
+        assertEquals(listOf("open"), results.map { it.nodeId })
+    }
+}

--- a/backend/src/test/kotlin/uk/co/fueller/backend/DataCacheTest.kt
+++ b/backend/src/test/kotlin/uk/co/fueller/backend/DataCacheTest.kt
@@ -83,9 +83,10 @@ class DataCacheTest {
 
         val results = cache.findNearby(51.5, -0.1, 50.0)
         assertTrue(results.isNotEmpty())
-        assertTrue(results.all { it.nodeId.startsWith("t") }) {
+        assertTrue(
+            results.all { it.nodeId.startsWith("t") },
             "expected only t* nodes after second ingest, got: ${results.map { it.nodeId }}"
-        }
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a configurable **ingest mode** so the deployed backend can serve real Fuel Finder data while its EC2 egress IP awaits whitelisting by the UK Fuel Finder support team.

- `mode=pull` (**default, unchanged**) — existing scheduled-fetch loop against Fuel Finder. Used in dev and once the EC2 IP is whitelisted.
- `mode=push` — backend's refresh loop is dormant; cache is populated by an external ingester (initially the project owner's already-whitelisted laptop) POSTing to a new authenticated `POST /admin/ingest` endpoint.

The mobile contract (`/api/search` `SearchResponse`) is **identical in both modes**, so the Android client needs no rebuild.

## Design

Full design rationale in `Fueller_LaptopIngest_Design.md` in the project workspace folder. Key points:

- **Atomic cache swap** — `DataCache` refactored from two `ConcurrentHashMap`s to two `AtomicReference<Map<…>>`s. Readers always see one consistent generation.
- **Auth** — shared secret `INGEST_TOKEN` env var, sent via `X-Ingest-Token` header. Constant-time comparison via `MessageDigest.isEqual`.
- **Out-of-order ingest** — 409 if `fetched_at` is older than the currently cached snapshot. Laptop logs and skips on 409.
- **Freshness** — new `staleAfterMinutes` (default 90); `/api/search` returns 503 if the cache is older than the threshold even when populated.
- **Mode-aware startup validation** — pull requires Fuel Finder creds; push requires `INGEST_TOKEN`. Server fails fast at startup if anything's missing.

## Files changed

```
backend/build.gradle.kts                        | tests, version bump 0.1.0 → 0.2.0
backend/src/main/resources/application.conf     | new config keys
backend/src/main/kotlin/.../Application.kt      | mode branch, validation
backend/src/main/kotlin/.../DataCache.kt        | AtomicReference, replaceFromIngest, isStale
backend/src/main/kotlin/.../IngestRoute.kt      | NEW — POST /admin/ingest
backend/src/main/kotlin/.../Models.kt           | IngestRequest/Response, HealthResponse extended
backend/src/main/kotlin/.../Routes.kt           | extended /api/health, stale gating
backend/src/test/kotlin/.../DataCacheTest.kt    | NEW — unit tests
README.md                                       | deployment-modes section
```

## Tests included

`DataCacheTest` covers:
- empty cache reports `isLoaded=false`, `isStale=true`
- `replaceFromIngest` populates and updates timestamps + ingester version
- `replaceFromIngest` fully replaces the previous set (no leftover keys)
- `isStale` boundary at the configured threshold
- `findNearby` radius filtering and sorting by distance
- `findNearby` excludes permanently-closed stations

Route-level tests (401/403/409 paths via `ktor-server-test-host`) intentionally **not** included in this PR — added in a follow-up to keep this change reviewable.

## Verification

Compilation **not yet verified in CI** — please run `./gradlew build` locally to confirm before merging. The shape was developed against the existing code in `main` and should be drop-in.

## How to switch the deployed backend to push mode

1. Generate a token: `openssl rand -base64 32 | tr -d '=' | tr '/+' '_-'`
2. On the EC2 host, set env vars: `FUEL_FINDER_MODE=push` + `INGEST_TOKEN=<token>`
3. Restart the backend.
4. On the laptop, configure the matching `INGEST_TOKEN` (laptop ingester is the next workstream item).
5. Watch `/api/health` — `mode: "push"`, `dataLoaded: false`, `isStale: true` until the first successful ingest.

## Migration back to pull mode

Once Fuel Finder whitelists the EC2 IP: set `FUEL_FINDER_MODE=pull` + `FUEL_FINDER_CLIENT_ID` + `FUEL_FINDER_CLIENT_SECRET`, redeploy. The push code stays in the codebase as a parallel path.

## Outstanding items

- Confirm Fuel Finder T&Cs cover the cached-intermediary distribution pattern (already on the launch workstream tracker as an outstanding action).
- Add ktor-test-host route tests in a follow-up.
- Add rate limiting on `/admin/ingest` (e.g., 10/15min per IP) before going public.
- TLS termination strategy for the EC2 deployment (out of scope here, but `/admin/ingest` must be HTTPS-only before this is publicly reachable).