### PR TITLE
fix(backend): handle nullable nodeId throughout DataCache

### DIFF
--- a/backend/src/main/kotlin/uk/co/fueller/backend/DataCache.kt
+++ b/backend/src/main/kotlin/uk/co/fueller/backend/DataCache.kt
@@ -85,7 +85,7 @@ class DataCache(
     private suspend fun loadStations() {
         log.info("Loading all stations...")
         val fetched = client.fetchAllStations()
-        stations.set(fetched.associateBy { it.nodeId })
+        stations.set(fetched.mapNotNull { s -> s.nodeId?.let { id -> id to s } }.toMap())
         lastStationRefresh = Instant.now()
         log.info("Loaded ${stations.get().size} stations")
     }
@@ -101,10 +101,10 @@ class DataCache(
         if (incremental && since != null) {
             // Merge incremental updates into the existing snapshot.
             val merged = prices.get().toMutableMap()
-            fetched.forEach { record -> merged[record.nodeId] = record.fuelPrices }
+            fetched.forEach { record -> record.nodeId?.let { merged[it] = record.fuelPrices } }
             prices.set(merged)
         } else {
-            prices.set(fetched.associate { it.nodeId to it.fuelPrices })
+            prices.set(fetched.mapNotNull { r -> r.nodeId?.let { id -> id to r.fuelPrices } }.toMap())
         }
         lastPriceRefresh = Instant.now()
         log.info("Loaded prices for ${fetched.size} stations (total cached: ${prices.get().size})")
@@ -122,8 +122,8 @@ class DataCache(
         fetchedAt: Instant,
         ingesterVersion: String? = null
     ) {
-        stations.set(newStations.associateBy { it.nodeId })
-        prices.set(newPrices.associate { it.nodeId to it.fuelPrices })
+        stations.set(newStations.mapNotNull { s -> s.nodeId?.let { id -> id to s } }.toMap())
+        prices.set(newPrices.mapNotNull { r -> r.nodeId?.let { id -> id to r.fuelPrices } }.toMap())
         lastPriceRefresh = fetchedAt
         lastStationRefresh = fetchedAt
         this.ingesterVersion = ingesterVersion
@@ -163,7 +163,7 @@ class DataCache(
                 ).joinToString(", ")
 
                 StationWithPrices(
-                    nodeId = station.nodeId,
+                    nodeId = station.nodeId!!,  // cache only contains non-null ids (filtered upstream)
                     name = station.tradingName ?: station.brandName ?: "Unknown",
                     brand = station.brandName,
                     address = address,


### PR DESCRIPTION
Follow-up to #16 (commit e47187e). Making `FuelFinderStation.nodeId` / `FuelFinderPriceRecord.nodeId` nullable in `Models.kt` left `DataCache.kt` failing to compile because it uses those fields as non-null `Map<String, _>` keys.

### What changed in `DataCache.kt`

| Site | Before | After |
|---|---|---|
| `loadStations()` | `fetched.associateBy { it.nodeId }` | `fetched.mapNotNull { s -> s.nodeId?.let { id -> id to s } }.toMap()` |
| `loadPrices()` (incremental merge) | `merged[record.nodeId] = record.fuelPrices` | `record.nodeId?.let { merged[it] = record.fuelPrices }` |
| `loadPrices()` (full replace) | `fetched.associate { it.nodeId to it.fuelPrices }` | `mapNotNull` equivalent |
| `replaceFromIngest()` | same `associateBy` / `associate` | `mapNotNull` equivalents |
| `StationWithPrices(nodeId = …)` | `station.nodeId` | `station.nodeId!!` with inline comment explaining the cache invariant |

### Why filter at the cache layer too

The pull path's `FuelFinderClient` already drops null-id records (e47187e), so this is belt-and-braces for pull. It's load-bearing for **push mode** — `replaceFromIngest()` consumes whatever the laptop ingester POSTs and didn't have a filter.

### Verification

- Local: this should now compile (the error list from the original failed build covered all six sites; each one is replaced verbatim).
- I have not built it in my sandbox — JDK 17 mirrors are blocked on my side. GavT to confirm `./gradlew :backend:shadowJar` succeeds locally before I redeploy.
